### PR TITLE
Crossentropy to NLL Loss

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "python.pythonPath": "/usr/bin/python3.6"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "/usr/bin/python3.6"
-}

--- a/train.py
+++ b/train.py
@@ -33,7 +33,7 @@ def evaluate(model, val_iter, vocab_size, DE, EN):
         src = Variable(src.data.cuda(), volatile=True)
         trg = Variable(trg.data.cuda(), volatile=True)
         output = model(src, trg)
-        loss = F.cross_entropy(output[1:].view(-1, vocab_size),
+        loss = F.nll_loss(output[1:].view(-1, vocab_size),
                                trg[1:].contiguous().view(-1),
                                ignore_index=pad)
         total_loss += loss.data[0]
@@ -50,7 +50,7 @@ def train(e, model, optimizer, train_iter, vocab_size, grad_clip, DE, EN):
         src, trg = src.cuda(), trg.cuda()
         optimizer.zero_grad()
         output = model(src, trg)
-        loss = F.cross_entropy(output[1:].view(-1, vocab_size),
+        loss = F.nll_loss(output[1:].view(-1, vocab_size),
                                trg[1:].contiguous().view(-1),
                                ignore_index=pad)
         loss.backward()


### PR DESCRIPTION
Changed crossentropy to nll_loss as crossentropy criterion combines log_softmax and nll_loss in a single function. Fixes #4