### PR TITLE
modify relu function

### DIFF
--- a/model.py
+++ b/model.py
@@ -40,7 +40,7 @@ class Attention(nn.Module):
         h = hidden.repeat(timestep, 1, 1).transpose(0, 1)
         encoder_outputs = encoder_outputs.transpose(0, 1)  # [B*T*H]
         attn_energies = self.score(h, encoder_outputs)
-        return F.relu(attn_energies, dim=1).unsqueeze(1)
+        return F.relu(attn_energies).unsqueeze(1)
 
     def score(self, hidden, encoder_outputs):
         # [B*T*2H]->[B*T*H]


### PR DESCRIPTION
The following error occurs when executing "train.py".

```
TypeError: relu() got an unexpected keyword argument 'dim'
```
I checked the official documentation of pyTorch and it was not necessary to specify "dim" in any version.
