### PR TITLE
Address #31 review: Bahdanau s_0 bridge, safe inference, single best.pt

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ Sanity check (CPU, 500 batches, hidden=128/embed=64):
 
 | step | train loss | perplexity |
 |------|-----------:|-----------:|
-| init |       9.20 |      9930 |
-|   50 |       6.95 |      1045 |
-|  100 |       5.46 |       236 |
-|  250 |       5.16 |       175 |
-|  500 |       4.89 |       133 |
+| init |       9.19 |      9803 |
+|   50 |       6.98 |      1071 |
+|  100 |       5.48 |       239 |
+|  250 |       5.15 |       173 |
+|  500 |       4.84 |       127 |
 
-Final val loss: **4.97** (random-init prior is `log(|V|) ≈ 9.19`).
+Final val loss: **4.93** (random-init prior is `log(|V|) ≈ 9.19`).
 
 ## References
 

--- a/model.py
+++ b/model.py
@@ -27,9 +27,8 @@ class Attention(nn.Module):
     def __init__(self, hidden_size):
         super().__init__()
         self.attn = nn.Linear(hidden_size * 2, hidden_size)
-        self.v = nn.Parameter(torch.rand(hidden_size))
-        stdv = 1. / math.sqrt(self.v.size(0))
-        self.v.data.uniform_(-stdv, stdv)
+        stdv = 1. / math.sqrt(hidden_size)
+        self.v = nn.Parameter(torch.empty(hidden_size).uniform_(-stdv, stdv))
 
     def forward(self, hidden, encoder_outputs):
         timestep = encoder_outputs.size(0)
@@ -54,11 +53,17 @@ class Decoder(nn.Module):
         self.n_layers = n_layers
         self.output_size = output_size
         self.embed = nn.Embedding(output_size, embed_size)
-        self.dropout = nn.Dropout(dropout, inplace=True)
+        self.dropout = nn.Dropout(dropout)
         self.attention = Attention(hidden_size)
         self.gru = nn.GRU(hidden_size + embed_size, hidden_size,
                           n_layers, dropout=dropout)
         self.out = nn.Linear(hidden_size * 2, output_size)
+        # Bahdanau §A.2.2: s_0 = tanh(W_s · ←h_1) from encoder's last backward state.
+        self.bridge = nn.Linear(hidden_size, hidden_size)
+
+    def init_hidden(self, encoder_hidden):
+        return torch.tanh(self.bridge(encoder_hidden[-1])).unsqueeze(0).repeat(
+            self.n_layers, 1, 1)
 
     def forward(self, input, last_hidden, encoder_outputs):
         embedded = self.dropout(self.embed(input).unsqueeze(0))  # (1,B,N)
@@ -89,10 +94,13 @@ class Seq2Seq(nn.Module):
         outputs = torch.zeros(max_len, batch_size, vocab_size,
                               device=src.device)
 
-        encoder_output, hidden = self.encoder(src)
-        hidden = hidden[:self.decoder.n_layers]
+        encoder_output, encoder_hidden = self.encoder(src)
+        hidden = self.decoder.init_hidden(encoder_hidden)
         output = trg[0] if trg is not None else torch.full(
             (batch_size,), sos, dtype=torch.long, device=src.device)
+        # Position 0 isn't predicted by the decoder; mark it as the start token
+        # so `outputs.argmax(-1)` reads back a complete token sequence.
+        outputs[0].scatter_(1, output.unsqueeze(1), 1.0)
         for t in range(1, max_len):
             output, hidden, _ = self.decoder(output, hidden, encoder_output)
             outputs[t] = output

--- a/train.py
+++ b/train.py
@@ -100,7 +100,7 @@ def main():
         if best_val_loss is None or val_loss < best_val_loss:
             print("[!] saving model...")
             os.makedirs(".save", exist_ok=True)
-            torch.save(seq2seq.state_dict(), f'./.save/seq2seq_{e}.pt')
+            torch.save(seq2seq.state_dict(), './.save/best.pt')
             best_val_loss, no_improve = val_loss, 0
         else:
             no_improve += 1

--- a/utils.py
+++ b/utils.py
@@ -31,18 +31,21 @@ def load_dataset(batch_size, dataset_name='bentrevett/multi30k'):
     tok_en = lambda t: [w.text.lower() for w in en_nlp.tokenizer(t)]
 
     raw = _hf_load_dataset(dataset_name)
-    train, val, test = raw['train'], raw['validation'], raw['test']
+    # Pre-tokenize once (cached to disk by HF datasets) so epochs don't re-spaCy.
+    tokenize = lambda ex: {'de': tok_de(ex['de']), 'en': tok_en(ex['en'])}
+    train, val, test = (raw[k].map(tokenize)
+                        for k in ('train', 'validation', 'test'))
 
     de_c, en_c = Counter(), Counter()
     for ex in train:
-        de_c.update(tok_de(ex['de']))
-        en_c.update(tok_en(ex['en']))
+        de_c.update(ex['de'])
+        en_c.update(ex['en'])
     DE = Vocab(de_c, min_freq=2)
     EN = Vocab(en_c, max_size=10000)
 
     def collate(batch):
-        src = [torch.tensor(DE.encode(tok_de(b['de']))) for b in batch]
-        trg = [torch.tensor(EN.encode(tok_en(b['en']))) for b in batch]
+        src = [torch.tensor(DE.encode(b['de'])) for b in batch]
+        trg = [torch.tensor(EN.encode(b['en'])) for b in batch]
         return (pad_sequence(src, padding_value=PAD),
                 pad_sequence(trg, padding_value=PAD))
 


### PR DESCRIPTION
## Summary

Follow-up to #31 addressing the code review findings.

### Bugs (HIGH)
- Drop `inplace=True` from decoder embedding dropout — autograd footgun on a non-leaf tensor.
- Write `outputs[0]` one-hot for the start token in `Seq2Seq.forward` — previously left as zeros, causing `outputs.argmax(-1)[0]` to silently return UNK in inference mode.

### Faithfulness (MEDIUM)
- Replace `hidden = encoder_hidden[:n_layers]` with a Bahdanau §A.2.2 bridge: `s_0 = tanh(W_s · ←h_1)` using the encoder's last backward state. The old slice silently kept only the encoder's *forward* direction — discarding the backward state that saw the start of the source first.

### Polish (MEDIUM / LOW)
- Save a single `best.pt` instead of `seq2seq_{e}.pt` per improving epoch.
- Pre-tokenize via `dataset.map` so spaCy doesn't re-run every epoch (cached to disk).
- Simplify attention `v` init.

### Re-verified
- 500-batch CPU run: train loss 9.19 → 4.84, **final val loss 4.93** (was 4.97 pre-bridge — small improvement, otherwise identical dynamics).
- `outputs[0].argmax(-1) == SOS` for all batch rows. ✓
- Faithful to Bahdanau additive attention now on: tanh score, `s_0 = tanh(W_s · ←h_1)` init, inference path that returns a complete token sequence.

### Remaining deviations (documented, not fixed — preserved for minimal LOC)
- Encoder annotations are still *summed* bidirectional outputs (Bahdanau concatenates).
- Output readout is `Linear([s_i; c_i])` without `y_{i-1}` and without maxout.

Net diff: +29 / -18 LOC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)